### PR TITLE
Make API GW send string and int to Data Cleaner

### DIFF
--- a/ms-data-cleaning/main.go
+++ b/ms-data-cleaning/main.go
@@ -58,7 +58,7 @@ func main() {
 	r := mux.NewRouter()
 
 	//Define your routes here. You may need to add more routes here.
-	r.HandleFunc("/route", handleRoute).Methods("POST")
+	r.HandleFunc("/timsfunc", handleRoute).Methods("POST")
 	r.HandleFunc("/route/with/{PARAM_NAME}", handleRouteParameter).Methods("GET")
 
 	//Serve the webserver. You should not change this

--- a/ms-data-cleaning/routes.go
+++ b/ms-data-cleaning/routes.go
@@ -11,7 +11,8 @@ import (
 
 //BodyStruct represents the body of a request. Add json fields below as needed
 type BodyStruct struct {
-	FName string `json:"fname"`
+	FName   string `json:"fname"`
+	ANumber int    `json:"anumber"`
 }
 
 //YOU WILL NEED TO CHANGE THIS TO THE REAL FUNCTIONALITY


### PR DESCRIPTION
This is the code we wrote during office hour live stream March 24th.

It shows how to make the api gateway issue a request to the data cleaning microservice and send both a String and an Int as part of the request.