### PR TITLE
Office hours 4/7 - Add DB cleaning function

### DIFF
--- a/ms-api-gateway/db.go
+++ b/ms-api-gateway/db.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"database/sql"
+	"fmt"
 	"log"
+	"os"
 )
 
 //Database controls database functionality
@@ -14,6 +16,14 @@ type Database struct {
 type LineCountRow struct {
 	Key   string
 	Count int
+}
+
+func (d *Database) ClearOldDB() {
+	err := os.Remove("../ETL.db")
+	if err != nil {
+		fmt.Println("Couldn't remove file: ", err)
+		return
+	}
 }
 
 //Store stores a logfile in a database
@@ -49,7 +59,7 @@ func (d *Database) dbInit() {
 	sqlStmt := `
 	CREATE TABLE IF NOT EXISTS logs (
 		name TEXT NOT NULL,
-		raw_log TEXT NOT NULL UNIQUE,
+		raw_log TEXT NOT NULL,
 		remote_addr TEXT,
 		time_local TEXT,
 		request_type TEXT,

--- a/ms-api-gateway/main.go
+++ b/ms-api-gateway/main.go
@@ -39,6 +39,9 @@ func main() {
 	//Start DB connection
 	LogStore = Database{}
 
+	// Remove old db file
+	LogStore.ClearOldDB()
+
 	//read config from file using viper.
 	ReadConfig()
 


### PR DESCRIPTION
Adds a function to delete the old DB each time ms-api gateway starts. This can help avoid bugs with duplicate log files. 

We also adjust the log table creation to allow a file to be uploaded more than once (by removing the unique log name criteria).